### PR TITLE
Added support for non-dimensional temperatures and PTm inputs

### DIFF
--- a/Python/seafreeze/seafreeze.py
+++ b/Python/seafreeze/seafreeze.py
@@ -5,7 +5,7 @@ import os.path as op
 import numpy as np
 from mlbspline import load
 from lbftd import evalGibbs as eg
-from lbftd.statevars import iP, iT
+from lbftd.statevars import iP, iT, iM
 
 defpath = op.join(op.dirname(op.abspath(__file__)), 'SeaFreeze_Gibbs.mat')
 
@@ -140,7 +140,7 @@ def whichphase(PTm, solute='water1', path=defpath):
         if p == 0:
             passPTm = PTm
         else:
-            passPTm = _get_PTm(PTm, isscatter)
+            passPTm = _get_PT(PTm, isscatter)
         sl = tuple(repeat(slice(None), 1 if isscatter else 2))+(p,)  # slice for this phase
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -203,7 +203,7 @@ def _get_T(PTm, is_scatter):
         return PTm[1]
 
 
-def _get_PTm(PTm, is_scatter):
+def _get_PT(PTm, is_scatter):
     if is_scatter:
         if len(PTm[0]) < 3:
             return PTm

--- a/Python/seafreeze/seafreeze.py
+++ b/Python/seafreeze/seafreeze.py
@@ -9,8 +9,8 @@ from lbftd.statevars import iP, iT
 
 defpath = op.join(op.dirname(op.abspath(__file__)), 'SeaFreeze_Gibbs.mat')
 
-def seafreeze(PT, phase, path=defpath):
-    """ Calculates thermodynamic quantities for H2O water or ice polymorphs Ih, III, V, and VI for all phases
+def seafreeze(PTm, phase, path=defpath):
+    """ Calculates thermodynamic quantities for H2O water or ice polymorphs Ih, II, III, V, and VI for all phases
         (see lbftd documentation for full list)
         for solid phases only:
             - Vp (compressional wave velocity, in m/s)
@@ -23,26 +23,42 @@ def seafreeze(PT, phase, path=defpath):
     Using other water parametrizations will lead to incorrect melting curves -- 'water2' and 'water_IAPWS95'
     parametrizations are provided for HP extension up to 100 GPa and comparison only.
 
-    :param PT:      the pressure (MPa) and temperature (K) conditions at which the thermodynamic quantities should be
+    :param PTm:     The pressure (MPa) and temperature (K) conditions at which the thermodynamic quantities should be
                     calculated -- the specified units are required, as conversions are built into several calculations.
+                    For solutes, molality (concentration in mol solute/kg solvent) is also required.
                     This parameter can have one of the following formats:
-                        - a 1-dimensional numpy array of tuples with one or more scattered (P,T) tuples, e.g.
-                                PT = np.empty((3,), np.object)
-                                PT[0] = (441.0858, 313.95)
-                                PT[1] = (478.7415, 313.96)
-                                PT[2] = (444.8285, 313.78)
-                        - a numpy array with 2 nested numpy arrays, the first with pressures and the second
-                          with temperatures -- each inner array must be sorted from low to high values
-                          a grid will be constructed from the P and T arrays such that each row of the output
-                          will correspond to a pressure and each column to a temperature, e.g.
+                        - Scatter-type input: a 1-dimensional numpy array of tuples with one or more
+                          (P,T) or (P,T,m) tuples, e.g.
+                                PTm = np.empty((3,), dtype=object)
+                                PTm[0] = (441.0858, 313.95)
+                                PTm[1] = (478.7415, 313.96)
+                                PTm[2] = (444.8285, 313.78)
+                            OR
+                                PTm = np.empty((3,), dtype=object)
+                                PTm[0] = (441.0858, 313.95, 24.9)
+                                PTm[1] = (478.7415, 313.96, 22.3)
+                                PTm[2] = (444.8285, 313.78, 23.7)                            
+                        - Grid-type input: a numpy array with 2 or 3 nested numpy arrays, the first with
+                          pressures, the second with temperatures, and the optional third with molality -- 
+                          each inner array must be sorted from low to high values. A grid will be constructed
+                          from the P and T arrays such that each row of the output will correspond to a
+                          pressure and each column to a temperature, e.g.
                                 P = np.arange(0.1, 1000.2, 10)
                                 T = np.arange(240, 501, 2)
-                                PT = np.array([P, T])
-    :param phase:   one of the keys of the phases dict, indicating the phase of H2O to be evaluated
-    :param path:    an optional path to the SeaFreeze_Gibbs.mat file
-                    default value assumes the spline distributed along with the project
-    :return:        object containing the calculated thermodynamic quantities (as named properties), as well as
-                    a PTM property (a copy of PT)
+                                PTm = np.array([P, T], dtype=object)
+                            OR
+                                m = np.arange(1, 10, 0.5)
+                                PTm = np.array([P, T, m], dtype=object)
+                          PT grids (for pure water or ices) must have axes of different lengths, or a quirk
+                          of numpy calculation handling will cause an error. Arrays of length 1 are permitted
+                          for grids across 2 input axes. Using np.squeeze() on the output is recommended to
+                          get a 2D grid as output, instead of a 3D grid with one axis of length 1.
+    :param phase:   One of the keys of the phases dict (bottom of this file), indicating the phase of H2O to
+                    be evaluated. Name of solute in the case of non-pure-H2O.
+    :param path:    An optional path to the SeaFreeze_Gibbs.mat file
+                    The default value assumes the spline distributed along with the project
+    :return:        SF output class object containing the calculated thermodynamic quantities (as named attributes),
+                    as well as a PTm property (a copy of PTm).
     """
     try:
         phasedesc = phases[phase]
@@ -52,96 +68,112 @@ def seafreeze(PT, phase, path=defpath):
     sp = load.loadSpline(path, phasedesc.sp_name)
     sp['MW'] = phasedesc.MW
     # calc density and isentropic bulk modulus
-    isscatter = _is_scatter(PT)
+    isscatter = _is_scatter(PTm)
     if sp['ndT']:
         # Dimensionless temperature is used, convert input T to dimensionless
         if isscatter:
-            PT[:,iT] = np.log(PT[:,iT]/sp['Tc'])
+            PTm[:,iT] = np.log(PTm[:,iT]/sp['Tc'])
         else:
-            PT[iT] = np.log(PT[iT]/sp['Tc'])
-    tdvs = _get_tdvs(sp, PT, isscatter)
+            PTm[iT] = np.log(PTm[iT]/sp['Tc'])
+    tdvs = _get_tdvs(sp, PTm, isscatter)
     if phasedesc.shear_mod_parms:
-        smg = _get_shear_mod_GPa(phasedesc.shear_mod_parms, tdvs.rho, _get_T(PT, isscatter))
+        smg = _get_shear_mod_GPa(phasedesc.shear_mod_parms, tdvs.rho, _get_T(PTm, isscatter))
         tdvs.shear = 1e3 * smg  # convert to MPa for consistency with other measures
         tdvs.Vp = _get_Vp(smg, tdvs.rho, tdvs.Ks)
         tdvs.Vs = _get_Vs(smg, tdvs.rho)
     return tdvs
 
 
-def whichphase(PT, solute='water1', path=defpath):
+def whichphase(PTm, solute='water1', path=defpath):
     """ Determines the most likely phase of water at each pressure/temperature
 
-    :param PT:      the pressure (MPa) and temperature (K) conditions at which the phase should be determined --
-                    the specified units are required, as conversions are built into several calculations.
+    :param PTm:     The pressure (MPa) and temperature (K) conditions at which the thermodynamic quantities should be
+                    calculated -- the specified units are required, as conversions are built into several calculations.
+                    For solutes, molality (concentration in mol solute/kg solvent) is also required.
                     This parameter can have one of the following formats:
-                        - a 1-dimensional numpy array of tuples with one or more scattered (P,T) tuples, e.g.
-                                PT = np.empty((3,), np.object)
-                                PT[0] = (441.0858, 313.95)
-                                PT[1] = (478.7415, 313.96)
-                                PT[2] = (444.8285, 313.78)
-                        - a numpy array with 2 nested numpy arrays, the first with pressures and the second
-                          with temperatures -- each inner array must be sorted from low to high values
-                          a grid will be constructed from the P and T arrays such that each row of the output
-                          will correspond to a pressure and each column to a temperature, e.g.
+                        - Scatter-type input: a 1-dimensional numpy array of tuples with one or more
+                          (P,T) or (P,T,m) tuples, e.g.
+                                PTm = np.empty((3,), dtype=object)
+                                PTm[0] = (441.0858, 313.95)
+                                PTm[1] = (478.7415, 313.96)
+                                PTm[2] = (444.8285, 313.78)
+                            OR
+                                PTm = np.empty((3,), dtype=object)
+                                PTm[0] = (441.0858, 313.95, 24.9)
+                                PTm[1] = (478.7415, 313.96, 22.3)
+                                PTm[2] = (444.8285, 313.78, 23.7)                            
+                        - Grid-type input: a numpy array with 2 or 3 nested numpy arrays, the first with
+                          pressures, the second with temperatures, and the optional third with molality -- 
+                          each inner array must be sorted from low to high values. A grid will be constructed
+                          from the P and T arrays such that each row of the output will correspond to a
+                          pressure and each column to a temperature, e.g.
                                 P = np.arange(0.1, 1000.2, 10)
                                 T = np.arange(240, 501, 2)
-                                PT = np.array([P, T])
-    :param solute:  an optional dissolved solute in the liquid phase.
-                    default is pure water (water1), and only NH3 is otherwise supported.
-    :param path:    an optional path to the SeaFreeze_Gibbs.mat file --
-                    default value assumes the spline distributed along with the project
-    :return:        A numpy.ndarray the same size as PT, with the phase of each pressure/temperature represented by
+                                PTm = np.array([P, T], dtype=object)
+                            OR
+                                m = np.arange(1, 10, 0.5)
+                                PTm = np.array([P, T, m], dtype=object)
+                          PT grids (for pure water or ices) must have axes of different lengths, or a quirk
+                          of numpy calculation handling will cause an error. Arrays of length 1 are permitted
+                          for grids across 2 input axes. Using np.squeeze() on the output is recommended to
+                          get a 2D grid as output, instead of a 3D grid with one axis of length 1.
+    :param solute:  An optional dissolved solute in the liquid phase.
+                    The default is pure water (water1).
+    :param path:    An optional path to the SeaFreeze_Gibbs.mat file --
+                    The default value assumes the spline distributed along with the project
+    :return:        A numpy.ndarray the same size as PTm, with the phase of each pressure/temperature represented by
                     an integer, as shown in phasenum2phase
     """
-    isscatter = _is_scatter(PT)
+    
+    isscatter = _is_scatter(PTm)
     phase_sp = {v.phase_num: load.loadSpline(path, v.sp_name) for pcomp, v in phases.items() if v.phase_num > 0 or pcomp == solute}
-    ptsh = (PT.size,) if isscatter else (PT[iP].size, PT[iT].size)    # reference shape based on PT
-    comp = np.full(ptsh + (max_phase_num+1,), np.nan)                  # comparison matrix
+    ptsh = (PTm.size,) if isscatter else (PTm[iP].size, PTm[iT].size)  # reference shape based on PTm
+    comp = np.full(ptsh + (max_phase_num+1,), np.nan)  # comparison matrix
     for p in phase_sp.keys():
         phase_sp[p]['MW'] = phases[phasenum2phase[p]].MW
         if phase_sp[p]['ndT']:
             # Dimensionless temperature is used, convert input T to dimensionless
             if isscatter:
-                PT[:,iT] = np.log(PT[:,iT]/phase_sp[p]['Tc'])
+                PTm[:,iT] = np.log(PTm[:,iT]/phase_sp[p]['Tc'])
             else:
-                PT[iT] = np.log(PT[iT]/phase_sp[p]['Tc'])
+                PTm[iT] = np.log(PTm[iT]/phase_sp[p]['Tc'])
         if p == 0:
-            passPT = PT
+            passPTm = PTm
         else:
-            passPT = _get_PT(PT, isscatter)
-        sl = tuple(repeat(slice(None), 1 if isscatter else 2))+(p,)     # slice for this phase
+            passPTm = _get_PTm(PTm, isscatter)
+        sl = tuple(repeat(slice(None), 1 if isscatter else 2))+(p,)  # slice for this phase
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             sp = phase_sp[p]
-            tdvs = _get_tdvs(sp, passPT, isscatter, 'G').G
-            # wipe out G for PT values that fall outside the knot sequence
+            tdvs = _get_tdvs(sp, passPTm, isscatter, 'G').G
+            # wipe out G for PTm values that fall outside the knot sequence
             if isscatter:
                 extrap = [(pt[iP] < sp['knots'][iP].min()) + (pt[iP] > sp['knots'][iP].max()) +
-                          (pt[iT] < sp['knots'][iT].min()) + (pt[iT] > sp['knots'][iT].max()) for pt in PT]
+                          (pt[iT] < sp['knots'][iT].min()) + (pt[iT] > sp['knots'][iT].max()) for pt in PTm]
             else:
-                pt = np.logical_or(PT[iP] < sp['knots'][iP].min(), PT[iP] > sp['knots'][iP].max())
-                tt = np.logical_or(PT[iT] < sp['knots'][iT].min(), PT[iT] > sp['knots'][iT].max())
+                pt = np.logical_or(PTm[iP] < sp['knots'][iP].min(), PTm[iP] > sp['knots'][iP].max())
+                tt = np.logical_or(PTm[iT] < sp['knots'][iT].min(), PTm[iT] > sp['knots'][iT].max())
                 extrap = np.logical_or(*np.meshgrid(pt, tt, indexing='ij'))
             tdvs[extrap] = np.nan
             comp[sl] = np.squeeze(tdvs)
     # output for all-nan slices should be nan
-    all_nan_sl = np.all(np.isnan(comp), -1)     # find slices where all values are nan along the innermost axis
-    out = np.full(ptsh, np.nan)        # initialize output to nan
-    out[~all_nan_sl] = np.nanargmin(comp[~all_nan_sl],-1)      # find min values for other slices
+    all_nan_sl = np.all(np.isnan(comp), -1)  # find slices where all values are nan along the innermost axis
+    out = np.full(ptsh, np.nan)  # initialize output to nan
+    out[~all_nan_sl] = np.nanargmin(comp[~all_nan_sl],-1)  # find min values for other slices
     return out
 
 
-def _get_tdvs(sp, PT, is_scatter, *tdvSpec):
-    """ peeks into PT to see if the PT data is for grid or scatter and calls the appropriate evalGibbs function
+def _get_tdvs(sp, PTm, is_scatter, *tdvSpec):
+    """ peeks into PTm to see if the PTm data is for grid or scatter and calls the appropriate evalGibbs function
 
     :param sp:          the Gibbs LBF
-    :param PT:          the PT data
-    :param is_scatter:  Boolean indicating whether the PT data is scatter or not (if not, it is a grid)
+    :param PTm:         the PTm data
+    :param is_scatter:  Boolean indicating whether the PTm data is scatter or not (if not, it is a grid)
     :param tdvSpec:     optional list of thermodynamic variables to calculate (see lbftd documentation)
     :return:            tdv object (see lbftd documentation)
     """
     fn = eg.evalSolutionGibbsScatter if is_scatter else eg.evalSolutionGibbsGrid
-    return fn(sp, PT, *tdvSpec, failOnExtrapolate=False, MWu=sp['MW'])
+    return fn(sp, PTm, *tdvSpec, failOnExtrapolate=False, MWu=sp['MW'])
 
 
 def _get_shear_mod_GPa(sm, rho, T):
@@ -156,29 +188,29 @@ def _get_Vs(smg, rho):
     return 1e3 * np.sqrt(smg/rho/1e-3)
 
 
-def _is_scatter(PT):
-    return isinstance(PT[0], tuple) or (PT.shape == (1,2) and np.isscalar(PT[0]) and np.isscalar(PT[1])) \
-        or (PT.shape == (1,3) and np.isscalar(PT[0]) and np.isscalar(PT[1]) and np.isscalar(PT[2]))
+def _is_scatter(PTm):
+    return isinstance(PTm[0], tuple) or (PTm.shape == (1,2) and np.isscalar(PTm[0]) and np.isscalar(PTm[1])) \
+        or (PTm.shape == (1,3) and np.isscalar(PTm[0]) and np.isscalar(PTm[1]) and np.isscalar(PTm[2]))
 
 
-def _get_T(PT, is_scatter):
+def _get_T(PTm, is_scatter):
     if is_scatter:
-        if len(PT[0]) < 3:
-            return np.array([T for P, T in PT])
+        if len(PTm[0]) < 3:
+            return np.array([T for P, T in PTm])
         else:
-            return np.array([T for P, T, m in PT])
+            return np.array([T for P, T, m in PTm])
     else:
-        return PT[1]
+        return PTm[1]
 
 
-def _get_PT(PT, is_scatter):
+def _get_PTm(PTm, is_scatter):
     if is_scatter:
-        if len(PT[0]) < 3:
-            return PT
+        if len(PTm[0]) < 3:
+            return PTm
         else:
-            return np.array([(P,T) for P, T, m in PT])
+            return np.array([(P,T) for P, T, m in PTm])
     else:
-        return PT[:2]
+        return PTm[:2]
 
 
 #########################################


### PR DESCRIPTION
Along with a pending pull request submitted to LocalBasisFunction (https://github.com/jmichaelb/LocalBasisFunction/pull/7), these edits add support for LBF splines that use non-dimensional temperatures. PTm inputs are now also supported for SeaFreeze calculations with solutes, which have an additional concentration input in mol/kg. Docstrings and variable names in seafreeze.py have been updated to reflect the optional m input.